### PR TITLE
Re-write ruby and crystal sources incorporating hash maps and a fresh mind

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
 a.out
 compare.txt
-getshells
 getshells-*

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 a.out
 compare.txt
+getshells
 getshells-*

--- a/compare.sh
+++ b/compare.sh
@@ -89,7 +89,7 @@ fi
 if [ -n "$(which crystal)" ];then
   CRPROG=getshells-cr
   crystal build --release getshells.cr
-  mv getshells ${CRPROG}
+  mv getshells ./${CRPROG}
 else
   echo "Crystal-lang not found."
 fi
@@ -97,6 +97,6 @@ fi
 for i in ${CPROG} ${RSPROG} ${GOPROG} ${NODEPROG} ${PYPROG} ${PLPROG} ${JLPROG} ${LISPPROG} ${RBPROG} ${AWK} ${CRPROG} ${PSHELL} 
 do
   echo "################################################"
-  echo $i
-  /usr/bin/time -f "\t%E real" ./${i}
+  echo "$i"
+  /usr/bin/time -f "\t%E real" "./${i}"
 done

--- a/getshells.cr
+++ b/getshells.cr
@@ -1,16 +1,21 @@
 #!/usr/bin/env crystal
 
-shellcnt = {} of String => Int32
+# Define a Hash to store the count of each login shell
+shellcnt = Hash(String, Int32).new(0)
 
-if File.exists?("passwd")
-   File.each_line("passwd") do |line|
-      gecos = line.chomp.split(':')
-      shell = gecos.last
-      shellcnt[shell] ||= 0
-      shellcnt[shell] += 1
-   end
+# Open the passwd file and iterate over each line
+File.open("passwd") do |file|
+  file.each_line do |line|
+    # Split the line into fields using colon as the delimiter
+    fields = line.chomp.split(':')
+    # Extract the login shell from the last field
+    shell = fields[-1]
+    # Increment the count of this login shell in the Hash
+    shellcnt[shell] += 1
+  end
+end
 
-   shellcnt.each do |key, value|
-      printf("%-20s%-8s%-d\n", key, ":", value)
-   end
+# Iterate over the Hash and print the counts for each login shell
+shellcnt.each do |key, value|
+  printf("%-20s%-8s%-d\n", key, ":", value)
 end

--- a/getshells.rb
+++ b/getshells.rb
@@ -1,21 +1,16 @@
 #!/usr/bin/env ruby
 
-shellcnt = {}
+shellcnt = Hash.new(0) # use Hash.new to create a new hash with a default value of 0 for any missing keys
 
 if File.exist?("passwd")
-   f = File.foreach("passwd") do |line|
-   line.chomp!
-   gecos = line.split(':')
-   shell = gecos.last
-    if shellcnt.has_key? shell
-       shellcnt[shell] = shellcnt[shell] + 1
-    else
-       shellcnt[shell] = 1
-    end
+  File.foreach("passwd") do |line|
+    line.chomp!
+    gecos = line.split(':')
+    shell = gecos.last
+    shellcnt[shell] += 1 # use the += operator to increment the value of each shell instead of using an if/else statement
   end
 
   shellcnt.each do |key, value|
     printf("%-20s%-8s%-d\n", key, ":", value)
-  end 
-
+  end
 end


### PR DESCRIPTION
Writeup on ruby edits:

- Use Hash.new(0) to create a new hash with a default value of 0 for any missing keys. This means the interpreter doesn't need to check if a key exists in the hash before incrementing its value, as any missing keys will automatically be initialized at a value of 0.

- Use the += operator to increment the value of each shell instead of using an if/else statement. This is a more concise and efficient way of incrementing values in a hash.

- Remove the unnecessary variable assignment of f = File.foreach("passwd"). The doesn't actually use the f variable anywhere, so it's better to just remove it.

Writeup on crystal edits:

- Change the type of shellcnt to Hash(String, Int32) instead of {} of String => Int32. This is a more explicit and speedy way to define a hash with String keys and Int32 values. This further differs crystal from the original ruby-isms I based this upon.

- Initialize the Hash with a default value of zero using .new(0). This avoids the need to check if a key exists in the Hash before incrementing its value. (like in ruby, the interpreter doesn't need to check if a key exists in the hash before incrementing its value, as any missing keys will automatically be initialized at a value of 0, because of this verbose assignment)

- Use File.open instead of File.exists? and File.each_line. This is more efficient because it only opens the file once and reads it line by line instead of loading the entire file into memory. This further differs crystal from the original ruby-isms I based this upon.

- Use fields[-1] instead of gecos.last to extract the login shell from the last field. This is more concise and avoids the need to assign a temporary variable, which frees a minimal amount of memory that the GC doesn't have to sludge through.