### PR TITLE
slightly more serious haskell implementation

### DIFF
--- a/compare.sh
+++ b/compare.sh
@@ -164,9 +164,9 @@ fi
 if [ -n "$(which ghc 2>/dev/null)" ]; then
 	HSPROG=getshells-hs
 	HSPROG_HYPER="./getshells-hs -n Haskell"
-	ghc -O getshells.hs -o ${HSPROG} -outputdir=/tmp
+	ghc -O3 -threaded getshells.hs -o ${HSPROG} -fforce-recomp -outputdir=/tmp
 else
-	echo "C Compiler not found."
+	echo "ghc (Haskell compiler) not found."
 fi
 
 LIST="${LUA} ${LUAJIT} ${CPROG} ${CPPPROG} ${RSPROG} ${M_RSPROG} ${GOPROG} ${NODEPROG} ${PYPROG} ${PLPROG} ${JLPROG} ${RBPROG} ${CRPROG} ${M_CRPROG} ${PLPROG} ${AWK} ${LISPPROG} ${PSHELL} ${HSPROG}"


### PR DESCRIPTION
 * use `Text` instead of `String`
 * `prettyPrint` no longer recurses list in favour of mapping it over the structure
 * use `Data.Map` instead of that abysmal (but very cool) `sort |> group |> fmap (\g -> (head g, length g))` pipeline

current cost profile :3 
```
                                                                                        individual      inherited
COST CENTRE      MODULE                  SRC                         no.     entries  %time %alloc   %time %alloc

MAIN             MAIN                    <built-in>                  198           0    0.1    0.0   100.0  100.0
 main            Main                    getshells.hs:(20,1)-(30,20) 397           0   54.4   61.2    99.9  100.0
  main.\         Main                    getshells.hs:29:26-49       402          19    0.1    0.0     0.1    0.0
   prettyPrint   Main                    getshells.hs:17:1-40        403          19    0.0    0.0     0.0    0.0
  main.shells    Main                    getshells.hs:(23,9)-(26,33) 398           1   27.4   17.8    45.4   38.8
   main.shells.\ Main                    getshells.hs:25:30-41       399     1067327    0.0    0.0     0.0    0.0
   lastColumn    Main                    getshells.hs:14:1-33        401           0   18.0   21.0    18.0   21.0
```