### PR TITLE
make zig version lean on libc for portability and fix openbsd compat (fixes #26)

### DIFF
--- a/src/getshells_zig/build.zig
+++ b/src/getshells_zig/build.zig
@@ -83,6 +83,9 @@ pub fn build(b: *std.Build) void {
         }),
     });
 
+    // Link to LibC
+    exe.root_module.link_libc = true;
+
     // This declares intent for the executable to be installed into the
     // install prefix when running `zig build` (i.e. when executing the default
     // step). By default the install prefix is `zig-out/` but can be overridden

--- a/src/getshells_zig/src/root.zig
+++ b/src/getshells_zig/src/root.zig
@@ -1,10 +1,13 @@
 // getshells - core logic
 // Reads a unix passwd file and tallies login shells
-// Uses std.posix / std.os.linux for cross-version compatibility
-// (tested on Zig 0.15.x and 0.17-dev)
+// Uses libc for posix library compatiblitly
+// Tested on zig 0.16.0
 const std = @import("std");
-const posix = std.posix;
-const linux = std.os.linux;
+
+const c = @cImport({
+    @cInclude("fcntl.h");
+    @cInclude("unistd.h");
+});
 
 const MAX_SHELLS = 64;
 const SHELL_LEN = 64;
@@ -38,8 +41,10 @@ fn processLine(
 }
 
 pub fn run() !void {
-    const fd = try posix.openat(posix.AT.FDCWD, "passwd", .{ .ACCMODE = .RDONLY }, 0);
-    defer _ = linux.close(fd);
+    const fd = c.open("passwd", c.O_RDONLY);
+    if (fd < 0)
+        return error.OpenFailed;
+    defer _ = c.close(fd);
 
     var shells = std.mem.zeroes([MAX_SHELLS]ShellName);
     var shell_lengths = std.mem.zeroes([MAX_SHELLS]usize);
@@ -51,14 +56,16 @@ pub fn run() !void {
     var line_len: usize = 0;
 
     while (true) {
-        const n = try posix.read(fd, &read_buf);
+        const n = c.read(fd, &read_buf, read_buf.len);
+        if (n < 0)
+            return error.ReadFailed;
         if (n == 0) break;
-        for (read_buf[0..n]) |c| {
-            if (c == '\n') {
+        for (read_buf[0..@intCast(n)]) |ch| {
+            if (ch == '\n') {
                 processLine(line_buf[0..line_len], &shells, &shell_lengths, &shellcnt, &numshells);
                 line_len = 0;
             } else if (line_len < line_buf.len) {
-                line_buf[line_len] = c;
+                line_buf[line_len] = ch;
                 line_len += 1;
             }
         }
@@ -79,9 +86,15 @@ pub fn run() !void {
 
     var written: usize = 0;
     while (written < out_pos) {
-        const rc = linux.write(posix.STDOUT_FILENO, out_buf[written..out_pos].ptr, out_pos - written);
-        const n = @as(isize, @bitCast(rc));
-        if (n < 0) return error.WriteError;
+        const n = c.write(
+            c.STDOUT_FILENO,
+            out_buf[written..out_pos].ptr,
+            out_pos - written,
+        );
+
+        if (n < 0)
+            return error.WriteFailed;
+
         written += @intCast(n);
     }
 }


### PR DESCRIPTION
tested on zig 0.16.0
fixes #26 