### PR TITLE
fix ub on older zig versions

### DIFF
--- a/src/getshells_zig/src/root.zig
+++ b/src/getshells_zig/src/root.zig
@@ -105,6 +105,6 @@ pub fn run() !void {
 
     var written: usize = 0;
     while (written < out_pos) {
-        written += try xwrite(posix.STDOUT_FILENO, out_buf[written..]);
+        written += try xwrite(posix.STDOUT_FILENO, out_buf[written..out_pos]);
     }
 }


### PR DESCRIPTION
fixes the garbage being printed to stdout after the normal output